### PR TITLE
Replace duplicate slide with missing slide and fix a link title

### DIFF
--- a/2018/README.md
+++ b/2018/README.md
@@ -20,10 +20,13 @@ The raw data from the survey is loated here [results.csv](results.csv)
 ![Survey Demographics](chart-demographics.png)
 
 ### Consensus About Role of Open Source Programs
-![Survey Demographics](chart-consensus-role-of-open-source-programs.png)
+![Consensus About Role of Open Source Programs](chart-consensus-role-of-open-source-programs.png)
 
 ### Challenges of Establishing an Open Source Program
 ![Challenges of Establishing an Open Source Program](chart-challenges-in-establishing-programs.png)
 
 ### Companies with an Open Source Program More Likely to Contribute
 ![Companies with an Open Source Program More Likely to Contribute](chart-companies-with-os-programs-more-likely-to-contribute.png)
+
+### Reasons for not Creating an Open Source Program
+![Reasons for not Creating an Open Source Program](chart-reasons-for-no-open-source-program.png)

--- a/2018/README.md
+++ b/2018/README.md
@@ -27,6 +27,3 @@ The raw data from the survey is loated here [results.csv](results.csv)
 
 ### Companies with an Open Source Program More Likely to Contribute
 ![Companies with an Open Source Program More Likely to Contribute](chart-companies-with-os-programs-more-likely-to-contribute.png)
-
-### Challenges in Establishing Open Source Programs
-![Challenges in Establishing Open Source Programs](chart-challenges-in-establishing-programs.png)


### PR DESCRIPTION
Just noticed a little error: one of the slides from 2018 was duplicated.  Otherwise, looks very good.