### PR TITLE
add SFDC to pool of companies to inquire about

### DIFF
--- a/2021/questions.md
+++ b/2021/questions.md
@@ -342,6 +342,7 @@ Address questions about the survey to research@thenewstack.io.
 * IBM
 * Microsoft
 * Red Hat
+* Salesforce
 * SAP
 * Uber
 * Verizon


### PR DESCRIPTION
This might introduce a slippery slope, but I'd love to add Salesforce to the list of companies we survey people about. Thanks for considering!